### PR TITLE
Add an absolute address to the image meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
-  <meta name="image" property="og:image" content="./app_screenshot.png" />
+  <meta name="image" property="og:image" content="https://raw.githubusercontent.com/HENRYKC24/simon-game/main/app_screenshot.png" />
   <title>KC Apps</title>
   <link rel="stylesheet" href="styles.css">
   <!-- <link href="https://fonts.googleapis.com/css?family=Press+Start+2P" rel="stylesheet"> -->


### PR DESCRIPTION
Add absolute image URL to the meta tag for image display on LinkedIn feature section.